### PR TITLE
[Bugfix] : [user] 에러 수정 및 기능 추가

### DIFF
--- a/src/main/java/com/blacky/our_island/controller/UserRestController.java
+++ b/src/main/java/com/blacky/our_island/controller/UserRestController.java
@@ -1,5 +1,7 @@
 package com.blacky.our_island.controller;
 
+import com.blacky.our_island.domain.dto.EmailCode.CodeRequest;
+import com.blacky.our_island.domain.dto.EmailCode.EmailRequest;
 import com.blacky.our_island.domain.dto.token.LoginResponseDto;
 import com.blacky.our_island.domain.dto.token.TokenDto;
 import com.blacky.our_island.domain.dto.token.TokenRequestDto;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -49,20 +52,41 @@ public class UserRestController {
     }
 
     // 인증 메일 보내기
-    @GetMapping("/send-auth-email")
+//    @PostMapping("/send-auth-email")
+//    @Operation(summary = "인증 메일 보내기", description = "인증 메일을 보냅니다.")
+//    public Response<String> sendAuthEmail(@RequestParam String email) throws Exception {
+//        System.out.println("email = " + email);
+//        return Response.success(emailService.sendLoginAuthMessage(email));
+//    }
+
+    @PostMapping("/send-auth-email")
     @Operation(summary = "인증 메일 보내기", description = "인증 메일을 보냅니다.")
-    public Response<String> sendAuthEmail(@RequestParam String email) throws Exception {
+    public Response<String> sendAuthEmail(@RequestBody EmailRequest request) throws Exception {
+        String email = request.getEmail();
         System.out.println("email = " + email);
         return Response.success(emailService.sendLoginAuthMessage(email));
     }
 
-    // 인증 메일 확인 하기
-    @GetMapping("/check-auth-email")
+
+//    // 인증 메일 확인 하기
+//    @PostMapping("/check-auth-email")
+//    @Operation(summary = "인증 코드 확인하기", description = "인증 코드를 확인합니다.")
+//    public Response<Boolean> checkAuthEmail(@RequestParam String code) {
+//        System.out.println(code);
+//        if (emailService.getData(code) == null) return Response.success(false);
+//        else return Response.success(true);
+//    }
+
+    @PostMapping("/check-auth-email")
     @Operation(summary = "인증 코드 확인하기", description = "인증 코드를 확인합니다.")
-    public Response<Boolean> checkAuthEmail(@RequestParam String code) {
+    public Response<Boolean> checkAuthEmail(@RequestBody CodeRequest request) {
+        String code = request.getCode();
         System.out.println(code);
-        if (emailService.getData(code) == null) return Response.success(false);
-        else return Response.success(true);
+        if (emailService.getData(code) == null) {
+            return Response.success(false);
+        } else {
+            return Response.success(true);
+        }
     }
 
     // 단일 조회, 전체 조회, 수정, 삭제 기능 추가

--- a/src/main/java/com/blacky/our_island/domain/Island.java
+++ b/src/main/java/com/blacky/our_island/domain/Island.java
@@ -33,7 +33,7 @@ public class Island extends BaseEntity {
     private String islandName;
 
     @Column(name = "Secret")
-    private Boolean Secret = true;  // Secret 필드에 아무런 값이 전달되지 않으면 기본값으로 true가 설정.
+    private Boolean Secret = false;  // Secret 필드에 아무런 값이 전달되지 않으면 기본값으로 false로 설정. (false= 공개)
 
     @Column(name = "island_introduce")
     @Size(max = 20)

--- a/src/main/java/com/blacky/our_island/domain/dto/EmailCode/CodeRequest.java
+++ b/src/main/java/com/blacky/our_island/domain/dto/EmailCode/CodeRequest.java
@@ -1,0 +1,11 @@
+package com.blacky.our_island.domain.dto.EmailCode;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CodeRequest {
+    private String code;
+
+}

--- a/src/main/java/com/blacky/our_island/domain/dto/EmailCode/EmailRequest.java
+++ b/src/main/java/com/blacky/our_island/domain/dto/EmailCode/EmailRequest.java
@@ -1,0 +1,11 @@
+package com.blacky.our_island.domain.dto.EmailCode;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailRequest {
+    private String email;
+
+}

--- a/src/main/java/com/blacky/our_island/domain/dto/token/LoginResponseDto.java
+++ b/src/main/java/com/blacky/our_island/domain/dto/token/LoginResponseDto.java
@@ -14,5 +14,6 @@ public class LoginResponseDto {
     private Long userId;
     private String nickname;
     private String character;
+    private String islandUniqueNumber;
 
 }

--- a/src/main/java/com/blacky/our_island/domain/dto/user/UserDto.java
+++ b/src/main/java/com/blacky/our_island/domain/dto/user/UserDto.java
@@ -1,6 +1,7 @@
 package com.blacky.our_island.domain.dto.user;
 
 import com.blacky.our_island.domain.entity.User;
+import com.blacky.our_island.domain.entity.UserDml;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,9 +19,13 @@ public class UserDto {
     private String nickname;
     private String character;
     private String role;
-    private Long islandId;
+    private Long islandId;          // 주석해야 하는지?
+    private String islandUniqueNumber;
 
 
+    // 회원가입에서 문제가 발생.
+    // 이 코드는 islandId값이 null이면 nullpointException 발생
+/*
     public static UserDto of (User user) {
         return UserDto.builder()
                 .userId(user.getUser_id())
@@ -29,10 +34,46 @@ public class UserDto {
                 .nickname(user.getNickname())
                 .role(user.getRole().name())
                 .character(user.getCharacter())
-                .islandId(user.getIslandId())
+                .islandId(user.getIsland().getIslandId())
                 .build();
     }
 
+ */
 
+    // 회원가입에서 islandId값이 null이면 null전달하도록.
+    public static UserDto of(User user) {
+
+        Long islandId = null;
+        String islandUniqueNumber = null;
+        if (user.getIsland() != null) {
+            islandId = user.getIsland().getIslandId();
+            islandUniqueNumber = user.getIsland().getIslandUniqueNumber();
+        }
+
+        return UserDto.builder()
+                .userId(user.getUser_id())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .nickname(user.getNickname())
+                .role(user.getRole().name())
+                .character(user.getCharacter())
+                .islandId(islandId)       // 수정된 부분
+                .islandUniqueNumber(islandUniqueNumber)  // 추가된 부분
+                .build();
+    }
+
+    // 회원 수정할 떄 조회용 UserDml 사용 로직
+    public static UserDto of(UserDml user) {
+
+        return UserDto.builder()
+                .userId(user.getUser_id())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .nickname(user.getNickname())
+                .role(user.getRole().name())
+                .character(user.getCharacter())
+                .islandId(user.getIslandId())       // 수정된 부분
+                .build();
+    }
 
 }

--- a/src/main/java/com/blacky/our_island/domain/entity/UserDml.java
+++ b/src/main/java/com/blacky/our_island/domain/entity/UserDml.java
@@ -1,6 +1,5 @@
 package com.blacky.our_island.domain.entity;
 
-import com.blacky.our_island.domain.Island;
 import com.blacky.our_island.domain.enum_class.Role;
 import lombok.*;
 
@@ -13,8 +12,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "User_TB")
-public class User extends BaseEntity{
-
+public class UserDml {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -37,25 +35,8 @@ public class User extends BaseEntity{
     @Column(name = "charactor")
     private String character;
 
-    // user와 island를 join 하기
-    @ManyToOne
-    @JoinColumn(name = "island_id")
-    private Island island;
-
-    public void changePassword(String newPassword) {
-        this.password = newPassword;
-    }
-
-    public void updateUser(String password) {
-        this.password = password;
-    }
+    @Column(name = "island_id")
+    private Long islandId;          // 수정된 부분
 
 
-    public void updateUser(String email, String password, String nickname, String character, Long islandId) {
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.character = character;
-        this.island.setIslandId(islandId);
-    }
 }

--- a/src/main/java/com/blacky/our_island/exception/ErrorCode.java
+++ b/src/main/java/com/blacky/our_island/exception/ErrorCode.java
@@ -8,23 +8,33 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    USER_NOT_FOUNDED(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DB에러"),
-    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "사용자가 권한이 없습니다."),
 
-    INVALID_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "Refresh Token이 유효하지 않습니다."),
-    LOGOUT_USER(HttpStatus.NOT_FOUND, "로그아웃 된 사용자입니다."),
-    TOKEN_NOT_MATCH(HttpStatus.UNAUTHORIZED,"토큰의 유저 정보가 일치하지 않습니다"),
-
-    DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "User Email이 중복됩니다."),
-    DUPLICATED_USER_NICKNAME(HttpStatus.CONFLICT, "User NickName이 중복됩니다."),
+    // 로그인
+    USER_NOT_FOUNDED(HttpStatus.UNAUTHORIZED, "유저를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 잘못되었습니다."),
 
-    DUPLICATED_ISLAND_UNIQUE_NUMBER(HttpStatus.CONFLICT, "island_unique_number이 중복됩니다."),
-    ISLAND_NOT_FOUND(HttpStatus.NOT_FOUND, "가족섬를 찾을 수 없습니다."),
+    // 회원가입
+    DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "User Email이 중복됩니다."),
 
+    // 인증
+    TOKEN_NOT_MATCH(HttpStatus.UNAUTHORIZED,"토큰의 유저 정보가 일치하지 않습니다"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
+    LOGOUT_USER(HttpStatus.UNAUTHORIZED, "로그아웃 된 사용자입니다."),
+
+    // 인가
+    INVALID_PERMISSION(HttpStatus.FORBIDDEN, "사용자가 권한이 없습니다."),
+
+    //    DUPLICATED_USER_NICKNAME(HttpStatus.CONFLICT, "User NickName이 중복됩니다."),
+    DUPLICATED_ISLAND_UNIQUE_NUMBER(HttpStatus.CONFLICT, "island_unique_number이 중복됩니다."),
+
+    ISLAND_NOT_FOUNDED(HttpStatus.BAD_REQUEST, "가족섬를 찾을 수 없습니다."),
     ;
 
     private HttpStatus status;
     private String message;
 }
+
+
+// 리소스를 찾을 수 없는 경우는 404에러 발생 O
+// 하지만, 인증 관련에서만 404에러는 되도록 사용 X

--- a/src/main/java/com/blacky/our_island/repository/UserDmlRepository.java
+++ b/src/main/java/com/blacky/our_island/repository/UserDmlRepository.java
@@ -1,0 +1,11 @@
+package com.blacky.our_island.repository;
+
+import com.blacky.our_island.domain.entity.User;
+import com.blacky.our_island.domain.entity.UserDml;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserDmlRepository extends JpaRepository<UserDml, Long> {
+    Optional<UserDml> findByEmail(String email);
+}

--- a/src/main/java/com/blacky/our_island/service/EmailService.java
+++ b/src/main/java/com/blacky/our_island/service/EmailService.java
@@ -64,7 +64,7 @@ public class EmailService {
         msgg += "<div style='margin:100px'>";
         msgg += "<h1>이메일 인증번호 안내</h1>";
         msgg += "<br>";
-        msgg += "<p>본 메일은 프로젝트 명 사이트의 회원가입을 위한 이메일 인증입니다.</p>";
+        msgg += "<p>본 메일은 우리 가족섬 APP의 회원가입을 위한 이메일 인증입니다.</p>";
         msgg += "<p>아래의 [이메일 인증번호]를 입력하여 본인확인을 해주시기 바랍니다.</p>";
         msgg += "<br>";
         msgg += "<p>감사합니다.</p>";
@@ -73,7 +73,7 @@ public class EmailService {
         msgg += "<div style='font-size:130%'>";
         msgg += "CODE : <strong>";
         msgg += ePw + "</strong><div><br />";
-        msgg += "<p>(코드의 유호시간은 5분입니다.)</p>";
+        msgg += "<p>(코드의 유효시간은 5분입니다.)</p>";
         msgg += "</div>";
         message.setText(msgg, "utf-8", "html");
         message.setFrom(new InternetAddress("blackymtvs@gmail.com", "우리 가족섬"));

--- a/src/main/java/com/blacky/our_island/service/IslandService.java
+++ b/src/main/java/com/blacky/our_island/service/IslandService.java
@@ -49,7 +49,7 @@ public class IslandService {
 
     public String getIslandUniqueNumber(Long islandId) {
         Island island = islandRepository.findById(islandId)
-                .orElseThrow(() -> new AppException(ErrorCode.ISLAND_NOT_FOUND));
+                .orElseThrow(() -> new AppException(ErrorCode.ISLAND_NOT_FOUNDED));
         return island.getIslandUniqueNumber();
     }
 


### PR DESCRIPTION
## ✨(#이슈번호) 제목
#66 #67 #68 #69 #70 #71 #72

## ✏️내용
1. user의 island_id값이 null이면 islandUniqueNumber을 null로 반환

2. Secret 필드에 아무런 값이 전달되지 않으면 기본값으로 false로 설정. (false= 공개)

3. 회원 정보 수정 시 password를 입력하지 않으면 에러 이슈 해결

4. 이메일 인증 메일이 발송되지 않는 이슈 해결 (Unity 통신)

5. island와 user를 join한 결과, 회원 가입시 에러 이슈 해결

6. 회원 수정 시 사용하는 DTO 따로 분리하여 수정 이슈 해결

7. 가족섬별 가족섬 오브젝트 컨트롤러에 Operation 부분 오타 수정
## 📸스크린샷

## 🎁참고사항